### PR TITLE
New classloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,4 @@ Maven central repository. Install it into your ant's lib/ directory or adjust ${
 point to maven-ant-tasks location.
 
 Since NOA-libre no longer bundles copies LibreOffice's URE and officebean jars, make sure to include URE and officebean in your
-application's runtime classpath. The build system will helpfully stick your system's likely location of that into manifest.mf
-(but of course might get it wrong).
+application's buildtime classpath.

--- a/build.xml
+++ b/build.xml
@@ -59,10 +59,6 @@
         <path refid="runtime.classpath" />
     </pathconvert>
 
-    <manifest file="manifest.mf">
-	<attribute name="Class-Path" value="${mf.classpath}" />
-    </manifest>
-
     <!-- Minimal LibreOffice version you want to build against. Beware,
          LibreOffice sometimes removes API in major releases -->
     <property name="libojars.version" value="5.0.3"/>

--- a/examples/calc/Snippet15.java
+++ b/examples/calc/Snippet15.java
@@ -1,116 +1,94 @@
-/****************************************************************************
- *                                                                          *
- * NOA (Nice Office Access)                                     						*
- * ------------------------------------------------------------------------ *
- *                                                                          *
- * The Contents of this file are made available subject to                  *
- * the terms of GNU Lesser General Public License Version 2.1.              *
- *                                                                          * 
- * GNU Lesser General Public License Version 2.1                            *
- * ======================================================================== *
- * Copyright 2003-2006 by IOn AG                                            *
- *                                                                          *
- * This library is free software; you can redistribute it and/or            *
- * modify it under the terms of the GNU Lesser General Public               *
- * License version 2.1, as published by the Free Software Foundation.       *
- *                                                                          *
- * This library is distributed in the hope that it will be useful,          *
- * but WITHOUT ANY WARRANTY; without even the implied warranty of           *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU        *
- * Lesser General Public License for more details.                          *
- *                                                                          *
- * You should have received a copy of the GNU Lesser General Public         *
- * License along with this library; if not, write to the Free Software      *
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston,                    *
- * MA  02111-1307  USA                                                      *
- *                                                                          *
- * Contact us:                                                              *
- *  http://www.ion.ag																												*
- *  http://ubion.ion.ag                                                     *
- *  info@ion.ag                                                             *
- *                                                                          *
- ****************************************************************************/
-
-/*
- * Last changes made by $Author: andreas $, $Date: 2006-10-04 14:14:28 +0200 (Mi, 04 Okt 2006) $
+/**
+ * This code snippet shows how to insert data in a calc document.
+ * Currently with UNO API access as it is not yet implemented in NOA.
+ *
+ * @author Markus Krüger
  */
-import ag.ion.bion.officelayer.application.IOfficeApplication;
-import ag.ion.bion.officelayer.application.OfficeApplicationRuntime;
 
-import ag.ion.bion.officelayer.document.DocumentDescriptor;
-import ag.ion.bion.officelayer.document.IDocument;
-import ag.ion.bion.officelayer.document.IDocumentService;
+package testapp;
 
-import ag.ion.bion.officelayer.spreadsheet.ISpreadsheetDocument;
+import java.util.HashMap;
 
 import com.sun.star.sheet.XSheetCellCursor;
 import com.sun.star.sheet.XSpreadsheet;
 import com.sun.star.sheet.XSpreadsheets;
-
 import com.sun.star.table.XCell;
-
 import com.sun.star.text.XText;
-
 import com.sun.star.uno.UnoRuntime;
 
-import java.util.HashMap;
+import ag.ion.bion.officelayer.application.IOfficeApplication;
+import ag.ion.bion.officelayer.application.OfficeApplicationRuntime;
+import ag.ion.bion.officelayer.document.DocumentDescriptor;
+import ag.ion.bion.officelayer.document.IDocument;
+import ag.ion.bion.officelayer.document.IDocumentService;
+import ag.ion.bion.officelayer.spreadsheet.ISpreadsheetDocument;
+import ag.ion.bion.officelayer.util.OfficeLoader;
 
-/**
- * This code snippet shows how to insert data in a calc document.
- * Currently with UNO API access as it is not yet implemented in NOA.
- * 
- * @author Markus Krüger
- * @version $Revision: 10398 $
- * @date 09.03.2007
- */
-public class Snippet15 {
 
-	/*
-	 * The path to the office application, in this case on a windows system.
-	 * 
-	 * On a Linux system this would look like: 
-	 * => private final static String officeHome = "/usr/lib/ooo-2.1"; 
-	 */
-	private final static String OPEN_OFFICE_ORG_PATH = "C:\\Programme\\OpenOffice.org 2.1"; 
-		
-	public static void main(String[] args) {
-		try {
-			HashMap configuration = new HashMap();
-			configuration.put(IOfficeApplication.APPLICATION_HOME_KEY, OPEN_OFFICE_ORG_PATH);
-			configuration.put(IOfficeApplication.APPLICATION_TYPE_KEY, IOfficeApplication.LOCAL_APPLICATION);
-			IOfficeApplication officeAplication = OfficeApplicationRuntime.getApplication(configuration);	
-			officeAplication.setConfiguration(configuration);
-			officeAplication.activate();
-			IDocumentService documentService = officeAplication.getDocumentService();
-			IDocument document = documentService.constructNewDocument(IDocument.CALC, DocumentDescriptor.DEFAULT);
-			ISpreadsheetDocument spreadsheetDocument = (ISpreadsheetDocument) document;
-      XSpreadsheets spreadsheets = spreadsheetDocument.getSpreadsheetDocument().getSheets();
-      String sheetName= "Tabelle1";
-      Object[][] rows = new Object[][]{
-          new Object[]{"DataCell1","DataCell2","DataCell3","DataCell4"},
-          new Object[]{new Integer(10),new Integer(20),new Integer(30),new Integer(40)},
-          new Object[]{new Double(11.11),new Double(22.22),new Double(33.33),new Double(44.44)}};
-      XSpreadsheet spreadsheet1 = (XSpreadsheet)UnoRuntime.queryInterface(XSpreadsheet.class,spreadsheets.getByName(sheetName));
-      //insert your Data
-      XSheetCellCursor cellCursor = spreadsheet1.createCursor();
-      for(int i = 0; i < rows.length; i++) {
-        Object[] cols = rows[i];
-        for(int j = 0; j < cols.length; j++) {
-          XCell cell= cellCursor.getCellByPosition(j,i);
-          XText cellText = (XText)UnoRuntime.queryInterface(XText.class, cell);
-          Object insert = cols[j];
-          if(insert instanceof Number)
-            cell.setValue(((Number)insert).doubleValue());
-          else if(insert instanceof String)
-            cellText.setString((String)insert);
-          else
-            cellText.setString(insert.toString());          
+public class SimpleCalcTest {
+
+    private final static String OPEN_OFFICE_ORG_PATH = "/usr/lib64/libreoffice/program";
+    public static HashMap<String, String> configuration = new HashMap<String, String>();
+    static {
+        configuration.put(IOfficeApplication.APPLICATION_HOME_KEY, OPEN_OFFICE_ORG_PATH);
+        configuration.put(IOfficeApplication.APPLICATION_TYPE_KEY, IOfficeApplication.LOCAL_APPLICATION);
+    }
+
+    public static void main(String[] args)
+    {
+        String testClass = SimpleCalcTestCore.class.getName();
+        String[] tmpArgs = new String[1];
+        tmpArgs[0] = testClass;
+
+        OfficeLoader.init(configuration);
+
+        try {
+           OfficeLoader.run( tmpArgs);
+        } catch (Exception e) {
+            e.printStackTrace();
         }
-      }
-		} 
-		catch (Throwable exception) {
-			exception.printStackTrace();
-		} 
-	}
+    }
 
+
+    public static class SimpleCalcTestCore {
+        public static void main(String[] args) {
+            try {
+                IOfficeApplication officeAplication = OfficeApplicationRuntime.getApplication(configuration);
+                officeAplication.setConfiguration(configuration);
+                officeAplication.activate();
+                IDocumentService documentService = officeAplication.getDocumentService();
+                IDocument document = documentService.constructNewDocument(IDocument.CALC, DocumentDescriptor.DEFAULT);
+                ISpreadsheetDocument spreadsheetDocument = (ISpreadsheetDocument) document;
+                XSpreadsheets spreadsheets = spreadsheetDocument.getSpreadsheetDocument().getSheets();
+                String sheetName= "Sheet1";
+                Object[][] rows = new Object[][]{
+                    new Object[]{"DataCell1","DataCell2","DataCell3","DataCell4"},
+                    new Object[]{new Integer(10),new Integer(20),new Integer(30),new Integer(40)},
+                    new Object[]{new Double(11.11),new Double(22.22),new Double(33.33),new Double(44.44)}};
+
+                XSpreadsheet spreadsheet1 = (XSpreadsheet)UnoRuntime.queryInterface(XSpreadsheet.class,spreadsheets.getByName(sheetName));
+                //insert your Data
+                XSheetCellCursor cellCursor = spreadsheet1.createCursor();
+
+                for(int i = 0; i < rows.length; i++) {
+                  Object[] cols = rows[i];
+
+                  for(int j = 0; j < cols.length; j++) {
+                    XCell cell= cellCursor.getCellByPosition(j,i);
+                    XText cellText = (XText)UnoRuntime.queryInterface(XText.class, cell);
+                    Object insert = cols[j];
+                    if(insert instanceof Number)
+                      cell.setValue(((Number)insert).doubleValue());
+                    else if(insert instanceof String)
+                      cellText.setString((String)insert);
+                    else
+                      cellText.setString(insert.toString());
+                   }
+                }
+            }
+            catch (Throwable exception) {
+                exception.printStackTrace();
+            }
+        }
+    }
 }

--- a/examples/calc/Snippet15.java
+++ b/examples/calc/Snippet15.java
@@ -5,7 +5,7 @@
  * @author Markus Krüger
  */
 
-package testapp;
+package simplecalctest;
 
 import java.util.HashMap;
 
@@ -36,14 +36,10 @@ public class SimpleCalcTest {
 
     public static void main(String[] args)
     {
-        String testClass = SimpleCalcTestCore.class.getName();
-        String[] tmpArgs = new String[1];
-        tmpArgs[0] = testClass;
-
         OfficeLoader.init(configuration);
 
         try {
-           OfficeLoader.run( tmpArgs);
+           OfficeLoader.run( new String[]{"simplecalctest.SimpleCalcTest$SimpleCalcTestCore"});
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/Lo4ConnectionTest.java
+++ b/src/Lo4ConnectionTest.java
@@ -1,62 +1,75 @@
+package lo4connectiontest;
 
-/*
- * Last changes made by $Author: andreas $, $Date: 2006-11-22 09:31:27 +0100 (Mi, 22 Nov 2006) $
- */
+import java.util.HashMap;
 
-import com.sun.star.beans.PropertyValue;
-import com.sun.star.comp.helper.Bootstrap;
-import com.sun.star.document.EventObject;
-import com.sun.star.document.XEventBroadcaster;
-import com.sun.star.document.XEventListener;
-import com.sun.star.lang.XComponent;
-import com.sun.star.uno.UnoRuntime;
+import ag.ion.bion.officelayer.application.IOfficeApplication;
+import ag.ion.bion.officelayer.util.OfficeLoader;
 
-/**
- * @author Andreas Bröker
- * @version $Revision: 11063 $
- */
 public class Lo4ConnectionTest {
 
-	public static void main(String[] args) {
-		com.sun.star.uno.XComponentContext xContext = null;
+    private final static String LIBREOFFICE_PATH = "/usr/lib64/libreoffice/program";
+    public static HashMap configuration = new HashMap();
 
-		try {
-			// get the remote office component context
-			xContext = Bootstrap.bootstrap();
-			if (xContext != null)
-				System.out.println("Connected to a running office ...");
-			com.sun.star.lang.XMultiComponentFactory xMCF = xContext
-					.getServiceManager();
-			Object oDesktop = xMCF.createInstanceWithContext(
-					"com.sun.star.frame.Desktop", xContext);
-			com.sun.star.frame.XComponentLoader xCompLoader = (com.sun.star.frame.XComponentLoader) UnoRuntime
-					.queryInterface(com.sun.star.frame.XComponentLoader.class,
-							oDesktop);
-			XComponent xComponent = xCompLoader.loadComponentFromURL(
-					"private:factory/swriter", "_blank", 0,
-					new PropertyValue[0]);
+    public static void main(String[] args){
+        configuration.put(IOfficeApplication.APPLICATION_HOME_KEY, LIBREOFFICE_PATH);
+        configuration.put(IOfficeApplication.APPLICATION_TYPE_KEY, IOfficeApplication.LOCAL_APPLICATION);
 
-			XEventBroadcaster xEventBroadcaster = (XEventBroadcaster) UnoRuntime
-					.queryInterface(XEventBroadcaster.class, xComponent);
-			if (xEventBroadcaster != null) {
-				// HERE COMES THE FIRST EXCEPTION
-				xEventBroadcaster.addEventListener(new XEventListener() {
+        String testClass = Lo4ConnectionTestCore.class.getName();
+        String[] tmpArgs = new String[1];
+        tmpArgs[0] = testClass;
 
-					@Override
-					public void disposing(com.sun.star.lang.EventObject arg0) {
-						System.out.println("disposing");
-					}
+        OfficeLoader.init(configuration);
 
-					@Override
-					public void notifyEvent(EventObject arg0) {
-						System.out.println("notifyEvent");
-					}
-				});
-			}
+        try {
+           OfficeLoader.run( tmpArgs );
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
 
-			System.exit(0);
-		} catch (Throwable throwable) {
-			throwable.printStackTrace();
-		}
-	}
+    public static class Lo4ConnectionTestCore {
+
+        public static void main(String[] args) {
+            com.sun.star.uno.XComponentContext xContext = null;
+
+            try {
+                // get the remote office component context
+                xContext = com.sun.star.comp.helper.Bootstrap.bootstrap();
+
+                if (xContext != null)
+                        System.out.println("Connected to a running office ...");
+
+                com.sun.star.lang.XMultiComponentFactory xMCF = xContext
+                            .getServiceManager();
+                Object oDesktop = xMCF.createInstanceWithContext(
+                            "com.sun.star.frame.Desktop", xContext);
+                com.sun.star.frame.XComponentLoader xCompLoader = (com.sun.star.frame.XComponentLoader) com.sun.star.uno.UnoRuntime
+                            .queryInterface(com.sun.star.frame.XComponentLoader.class,oDesktop);
+                com.sun.star.lang.XComponent xComponent = xCompLoader.loadComponentFromURL(
+                            "private:factory/swriter", "_blank", 0,
+                            new com.sun.star.beans.PropertyValue[0]);
+
+                com.sun.star.document.XEventBroadcaster xEventBroadcaster = (com.sun.star.document.XEventBroadcaster) com.sun.star.uno.UnoRuntime
+                            .queryInterface(com.sun.star.document.XEventBroadcaster.class, xComponent);
+                if (xEventBroadcaster != null) {
+                    // HERE COMES THE FIRST EXCEPTION
+                    xEventBroadcaster.addEventListener(new com.sun.star.document.XEventListener() {
+
+                        @Override
+                        public void disposing(com.sun.star.lang.EventObject arg0) {
+                                    System.out.println("disposing");
+                        }
+
+                        @Override
+                        public void notifyEvent(com.sun.star.document.EventObject arg0) {
+                                    System.out.println("notifyEvent");
+                         }
+                    });
+                }
+                System.exit(0);
+           } catch (Throwable throwable) {
+              throwable.printStackTrace();
+           }
+        }
+    }
 }

--- a/src/Lo4ConnectionTest.java
+++ b/src/Lo4ConnectionTest.java
@@ -16,14 +16,10 @@ public class Lo4ConnectionTest {
 
     public static void main(String[] args){
 
-        String testClass = Lo4ConnectionTestCore.class.getName();
-        String[] tmpArgs = new String[1];
-        tmpArgs[0] = testClass;
-
         OfficeLoader.init(configuration);
 
         try {
-           OfficeLoader.run( tmpArgs );
+           OfficeLoader.run( new String[]{"lo4connectiontest.Lo4ConnectionTest$Lo4ConnectionTestCore"});
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/Lo4ConnectionTest.java
+++ b/src/Lo4ConnectionTest.java
@@ -8,11 +8,13 @@ import ag.ion.bion.officelayer.util.OfficeLoader;
 public class Lo4ConnectionTest {
 
     private final static String LIBREOFFICE_PATH = "/usr/lib64/libreoffice/program";
-    public static HashMap configuration = new HashMap();
-
-    public static void main(String[] args){
+    public static HashMap<String, String> configuration = new HashMap<String, String>();
+    static {
         configuration.put(IOfficeApplication.APPLICATION_HOME_KEY, LIBREOFFICE_PATH);
         configuration.put(IOfficeApplication.APPLICATION_TYPE_KEY, IOfficeApplication.LOCAL_APPLICATION);
+    }
+
+    public static void main(String[] args){
 
         String testClass = Lo4ConnectionTestCore.class.getName();
         String[] tmpArgs = new String[1];

--- a/src/ag/ion/bion/officelayer/util/InstallationFinder.java
+++ b/src/ag/ion/bion/officelayer/util/InstallationFinder.java
@@ -1,0 +1,587 @@
+/*
+ * This file is part of the LibreOffice project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This file incorporates work covered by the following license notice:
+ *
+ *   Licensed to the Apache Software Foundation (ASF) under one or more
+ *   contributor license agreements. See the NOTICE file distributed
+ *   with this work for additional information regarding copyright
+ *   ownership. The ASF licenses this file to you under the Apache
+ *   License, Version 2.0 (the "License"); you may not use this file
+ *   except in compliance with the License. You may obtain a copy of
+ *   the License at http://www.apache.org/licenses/LICENSE-2.0 .
+ */
+
+package ag.ion.bion.officelayer.util;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.StringTokenizer;
+import java.util.ArrayList;
+
+/**
+ * This class finds a UNO installation on the system.
+ *
+ * <p>A UNO installation can be specified by the user by either setting the
+ * com.sun.star.lib.loader.unopath system property or by setting the
+ * UNO_PATH environment variable to the program directory of a UNO
+ * installation.
+ * Note, that Java 1.3.1 and Java 1.4 don't support environment variables
+ * (System.getenv() throws java.lang.Error) and therefore setting the UNO_PATH
+ * environment variable won't work with those Java versions.
+ * If no UNO installation is specified by the user, the default installation
+ * on the system will be returned.</p>
+ *
+ * <p>On the Windows platform the default installation is read from the Windows
+ * Registry.</p>
+ *
+ * <p>On the Unix/Linux platforms the default installation is found from the
+ * PATH environment variable. Note, that for Java 1.3.1 and Java 1.4 the
+ * default installation is found by using the 'which' command, because
+ * environment variables are not supported with those Java versions.
+ * Both methods require that the 'soffice' executable or a symbolic
+ * link is in one of the directories listed in the PATH environment variable.
+ * For older versions than OOo 2.0 the above described methods may fail.
+ * In this case the default installation is taken from the .sversionrc file in
+ * the user's home directory. Note, that the .sversionrc file will be omitted
+ * for OOo 2.0</p>
+ */
+final class InstallationFinder {
+
+    private static final String SYSPROP_NAME =
+        "com.sun.star.lib.loader.unopath";
+    private static final String ENVVAR_NAME = "UNO_PATH";
+    private static final String SOFFICE = "libreoffice"; // Unix/Linux only
+
+    private InstallationFinder() {} // do not instantiate
+
+    /**
+     * Gets the path of a UNO installation.
+     *
+     * @return the installation path or <code>null</code>, if no installation
+     *         was specified or found, or if an error occurred
+     */
+    public static String getPath() {
+
+        String path = null;
+
+        // get the installation path from the Java system property
+        // com.sun.star.lib.loader.unopath
+        // (all platforms)
+        path = getPathFromProperty( SYSPROP_NAME );
+        if ( path != null ) {
+            return path;
+        }
+        // get the installation path from the UNO_PATH environment variable
+        // (all platforms, not working for Java 1.3.1 and Java 1.4)
+        path = getPathFromEnvVar( ENVVAR_NAME );
+        if ( path != null ) {
+            return path;
+        }
+
+        String osname = null;
+        try {
+            osname = System.getProperty( "os.name" );
+        } catch ( SecurityException e ) {
+            // if a SecurityException was thrown,
+            // return <code>null</code>
+            return null;
+        }
+        if ( osname == null ) {
+            return null;
+        }
+
+        if ( osname.startsWith( "Windows" ) ) {
+            // get the installation path from the Windows Registry
+            // (Windows platform only)
+            path = getPathFromWindowsRegistry();
+        } else {
+            // get the installation path from the PATH environment
+            // variable (Unix/Linux platforms only, not working for
+            // Java 1.3.1 and Java 1.4)
+            path = getPathFromPathEnvVar();
+            if ( path == null ) {
+                // get the installation path from the 'which'
+                // command (Unix/Linux platforms only)
+                path = getPathFromWhich();
+                if ( path == null ) {
+                    // get the installation path from the
+                    // .sversionrc file (Unix/Linux platforms only,
+                    // for older versions than OOo 2.0)
+                    path = getPathFromSVersionFile();
+                }
+            }
+        }
+
+        return path;
+    }
+
+    /**
+     * Gets the installation path from a Java system property.
+     *
+     * <p>This method is called on all platforms.
+     * The Java system property can be passed into the application by using
+     * the -D flag, e.g.
+     * java -D<property name>=<installation path> -jar application.jar.</p>
+     *
+     * @return the installation path or <code>null</code>, if no installation
+     *         was specified in the Java system property or if an error occurred
+     */
+    private static String getPathFromProperty( String prop ) {
+
+        String path = null;
+
+        try {
+            path = System.getProperty( prop );
+        } catch ( SecurityException e ) {
+            // if a SecurityException was thrown, return <code>null</code>
+        }
+
+        return path;
+    }
+
+    /**
+     * Gets the installation path from an environment variable.
+     *
+     * <p>This method is called on all platforms.
+     * Note, that in Java 1.3.1 and Java 1.4 System.getenv() throws
+     * java.lang.Error and therefore this method returns null for those
+     * Java versions.</p>
+     *
+     * @return the installation path or <code>null</code>, if no installation
+     *         was specified in the environment variable or if an error occurred
+     */
+    private static String getPathFromEnvVar( String var ) {
+
+        String path = null;
+
+        try {
+            path = System.getenv( var );
+        } catch ( SecurityException e ) {
+            // if a SecurityException was thrown, return <code>null</code>
+        } catch ( java.lang.Error err ) {
+            // System.getenv() throws java.lang.Error in Java 1.3.1 and
+            // Java 1.4
+        }
+
+        return path;
+    }
+
+    /**
+     * Gets the installation path from the Windows Registry.
+     *
+     * <p>This method is called on the Windows platform only.</p>
+     *
+     * @return the installation path or <code>null</code>, if no installation
+     *         was found or if an error occurred
+     */
+    private static String getPathFromWindowsRegistry() {
+
+        final String SUBKEYNAME = "Software\\LibreOffice\\UNO\\InstallPath";
+
+        String path = null;
+
+        try {
+            // read the key's default value from HKEY_CURRENT_USER
+            WinRegKey key = new WinRegKey( "HKEY_CURRENT_USER", SUBKEYNAME );
+            path = key.getStringValue( "" ); // default
+        } catch ( WinRegKeyException e ) {
+            try {
+                // read the key's default value from HKEY_LOCAL_MACHINE
+                WinRegKey key = new WinRegKey( "HKEY_LOCAL_MACHINE",
+                                               SUBKEYNAME );
+                path = key.getStringValue( "" ); // default
+            } catch ( WinRegKeyException we ) {
+                System.err.println( "ag.ion.bion.officelayer.util." +
+                    "InstallationFinder::getPathFromWindowsRegistry: " +
+                    "reading key from Windows Registry failed: " + we );
+            }
+        }
+
+        return path;
+    }
+
+    /**
+     * Gets the installation path from the PATH environment variable.
+     *
+     * <p>This method is called on Unix/Linux platforms only.
+     * An installation is found, if the executable 'soffice' or a symbolic link
+     * is in one of the directories listed in the PATH environment variable.
+     * Note, that in Java 1.3.1 and Java 1.4 System.getenv() throws
+     * java.lang.Error and therefore this method returns null for those
+     * Java versions.</p>
+     *
+     * @return the installation path or <code>null</code>, if no installation
+     *         was found or if an error occurred
+     */
+    private static String getPathFromPathEnvVar() {
+
+        final String PATH_ENVVAR_NAME = "PATH";
+
+        String path = null;
+        String str = null;
+
+        try {
+            str = System.getenv( PATH_ENVVAR_NAME );
+        } catch ( SecurityException e ) {
+            // if a SecurityException was thrown, return <code>null</code>
+            return null;
+        } catch ( java.lang.Error err ) {
+            // System.getenv() throws java.lang.Error in Java 1.3.1 and
+            // Java 1.4
+            return null;
+        }
+
+        if ( str != null ) {
+            StringTokenizer tokens = new StringTokenizer(
+                str, File.pathSeparator );
+            while ( tokens.hasMoreTokens() ) {
+                File file = new File( tokens.nextToken(), SOFFICE );
+                try {
+                    if ( file.exists() ) {
+                        try {
+                            // resolve symlink
+                            path = file.getCanonicalFile().getParent();
+                            if ( path != null )
+                                break;
+                        } catch ( IOException e ) {
+                            // if an I/O exception is thrown, ignore this
+                            // path entry and try the next one
+                            System.err.println( "ag.ion.bion.officelayer.util." +
+                                "InstallationFinder::getPathFromEnvVar: " +
+                                "bad path: " + e );
+                        }
+                    }
+                } catch ( SecurityException e ) {
+                    // if a SecurityException was thrown, ignore this path
+                    // entry and try the next one
+                }
+            }
+        }
+
+        return path;
+    }
+
+    /**
+     * Gets the installation path from the 'which' command on Unix/Linux
+     * platforms.
+     *
+     * <p>This method is called on Unix/Linux platforms only.
+     * An installation is found, if the executable 'soffice' or a symbolic link
+     * is in one of the directories listed in the PATH environment variable.</p>
+     *
+     * @return the installation path or <code>null</code>, if no installation
+     *         was found or if an error occurred
+     */
+    private static String getPathFromWhich() {
+
+        final String WHICH = "which";
+
+        String path = null;
+
+        // start the which process
+        String[] cmdArray = new String[] { WHICH, SOFFICE };
+        Process proc = null;
+        Runtime rt = Runtime.getRuntime();
+        try {
+            proc = rt.exec( cmdArray );
+        } catch ( SecurityException e ) {
+            return null;
+        } catch ( IOException e ) {
+            // if an I/O exception is thrown, return <code>null</null>
+            System.err.println( "ag.ion.bion.officelayer.util." +
+                "InstallationFinder::getPathFromWhich: " +
+                "which command failed: " + e );
+            return null;
+        }
+
+        // empty standard error stream in a separate thread
+        StreamGobbler gobbler = new StreamGobbler( proc.getErrorStream() );
+        gobbler.start();
+
+        try {
+            // read the which output from standard input stream
+            BufferedReader br = new BufferedReader(
+                new InputStreamReader( proc.getInputStream(), "UTF-8" ) );
+            String line = null;
+            try {
+                while ( ( line = br.readLine() ) != null ) {
+                    if ( path == null ) {
+                        // get the path from the which output
+                        int index = line.lastIndexOf( SOFFICE );
+                        if ( index != -1 ) {
+                            int end = index + SOFFICE.length();
+                            for ( int i = 0; i <= index; i++ ) {
+                                File file = new File( line.substring( i, end ) );
+                                try {
+                                    if ( file.exists() ) {
+                                        // resolve symlink
+                                        path = file.getCanonicalFile().getParent();
+                                        if ( path != null )
+                                            break;
+                                    }
+                                } catch ( SecurityException e ) {
+                                    return null;
+                                }
+                            }
+                        }
+                    }
+                }
+            } catch ( IOException e ) {
+                // if an I/O exception is thrown, return <code>null</null>
+                System.err.println( "ag.ion.bion.officelayer.util." +
+                                    "InstallationFinder::getPathFromWhich: " +
+                                    "reading which command output failed: " + e );
+                return null;
+            } finally {
+                try {
+                    br.close();
+                } catch ( IOException e ) {
+                    // closing standard input stream failed, ignore
+                }
+            }
+        } catch ( UnsupportedEncodingException e ) {
+            // if an Encoding exception is thrown, return <code>null</null>
+            System.err.println( "ag.ion.bion.officelayer.util." +
+                                "InstallationFinder::getPathFromWhich: " +
+                                "encoding failed: " + e );
+            return null;
+        }
+
+        try {
+            // wait until the which process has terminated
+            proc.waitFor();
+        } catch ( InterruptedException e ) {
+            // the current thread was interrupted by another thread,
+            // kill the which process
+            proc.destroy();
+            // set the interrupted status
+            Thread.currentThread().interrupt();
+        }
+
+        return path;
+    }
+
+    /**
+     * Gets the installation path from the .sverionrc file in the user's home
+     * directory.
+     *
+     * <p>This method is called on Unix/Linux platforms only.
+     * The .sversionrc file is written during setup and will be omitted for
+     * OOo 2.0.</p>
+     *
+     * @return the installation path or <code>null</code>, if no installation
+     *         was found or if an error occurred
+     */
+    private static String getPathFromSVersionFile() {
+
+        final String SVERSION = ".sversionrc"; // Unix/Linux only
+        final String VERSIONS = "[Versions]";
+
+        String path = null;
+
+        try {
+            File fSVersion = new File(
+                System.getProperty( "user.home" ) ,SVERSION );
+            if ( fSVersion.exists() ) {
+                ArrayList<String> lines = new ArrayList<String>();
+                BufferedReader br = null;
+                try {
+                    br = new BufferedReader( new InputStreamReader(
+                        new FileInputStream( fSVersion ), "UTF-8" ) );
+                    String line = null;
+                    while ( ( line = br.readLine() ) != null &&
+                            !line.equals( VERSIONS ) ) {
+                        // read lines until [Versions] is found
+                    }
+                    while ( ( line = br.readLine() ) != null &&
+                            line.length() != 0 ) {
+                        if ( !line.startsWith( ";" ) )
+                            lines.add( line );
+                    }
+                } catch ( IOException e ) {
+                    // if an I/O exception is thrown, try to analyze the lines
+                    // read so far
+                    System.err.println( "ag.ion.bion.officelayer.util" +
+                        "InstallationFinder::getPathFromSVersionFile: " +
+                        "reading .sversionrc file failed: " + e );
+                } finally {
+                    if ( br != null ) {
+                        try {
+                            br.close();
+                        } catch ( IOException e ) {
+                            // closing .sversionrc failed, ignore
+                        }
+                    }
+                }
+                for ( int i = lines.size() - 1; i >= 0; i-- ) {
+                    StringTokenizer tokens = new StringTokenizer(
+                        lines.get( i ), "=" );
+                    if ( tokens.countTokens() != 2 )
+                        continue;
+                    tokens.nextToken(); // key
+                    String url = tokens.nextToken();
+                    path = getCanonicalPathFromFileURL( url );
+                    if ( path != null )
+                        break;
+                }
+            }
+        } catch ( SecurityException e ) {
+            return null;
+        }
+
+        return path;
+    }
+
+    /**
+     * Translates an OOo-internal absolute file URL reference (encoded using
+     * UTF-8) into a Java canonical pathname.
+     *
+     * @param oooUrl any URL reference; any fragment part is ignored
+     *
+     * @return if the given URL is a valid absolute, local (that is, the host
+     * part is empty or equal to "localhost", ignoring case) file URL, it is
+     * converted into an absolute canonical pathname; otherwise,
+     * <code>null</code> is returned
+     */
+    private static String getCanonicalPathFromFileURL( String oooUrl ) {
+
+        String prefix = "file://";
+        if (oooUrl.length() < prefix.length()
+            || !oooUrl.substring(0, prefix.length()).equalsIgnoreCase(
+                prefix))
+        {
+            return null;
+        }
+        StringBuffer buf = new StringBuffer(prefix);
+        int n = oooUrl.indexOf('/', prefix.length());
+        if (n < 0) {
+            n = oooUrl.length();
+        }
+        String host = oooUrl.substring(prefix.length(), n);
+        if (host.length() != 0 && !host.equalsIgnoreCase("localhost")) {
+            return null;
+        }
+        buf.append(host);
+        if (n == oooUrl.length()) {
+            buf.append('/');
+        } else {
+        loop:
+            while (n < oooUrl.length()) {
+                buf.append('/');
+                ++n;
+                int n2 = oooUrl.indexOf('/', n);
+                if (n2 < 0) {
+                    n2 = oooUrl.length();
+                }
+                while (n < n2) {
+                    char c = oooUrl.charAt(n);
+                    switch (c) {
+                    case '%':
+                        byte[] bytes = new byte[(n2 - n) / 3];
+                        int len = 0;
+                        while (oooUrl.length() - n > 2
+                               && oooUrl.charAt(n) == '%')
+                        {
+                            int d1 = Character.digit(oooUrl.charAt(n + 1), 16);
+                            int d2 = Character.digit(oooUrl.charAt(n + 2), 16);
+                            if (d1 < 0 || d2 < 0) {
+                                break;
+                            }
+                            int d = 16 * d1 + d2;
+                            if (d == '/') {
+                                return null;
+                            }
+                            bytes[len++] = (byte) d;
+                            n += 3;
+                        }
+                        String s;
+                        try {
+                            s = new String(bytes, 0, len, "UTF-8");
+                        } catch (UnsupportedEncodingException e) {
+                            return null;
+                        }
+                        buf.append(s);
+                        break;
+
+                    case '#':
+                        break loop;
+
+                    default:
+                        buf.append(c);
+                        ++n;
+                        break;
+                    }
+                }
+            }
+        }
+        URL url;
+        try {
+            url = new URL(buf.toString());
+        } catch (MalformedURLException e) {
+            return null;
+        }
+        String path = url.getFile();
+        String fragment = url.getRef();
+        if (fragment != null) {
+            path += '#' + fragment;
+        }
+        String ret = null;
+        File file = new File( path, SOFFICE );
+        try {
+            if ( file.isAbsolute() && file.exists() ) {
+                try {
+                    // resolve symlink
+                    ret = file.getCanonicalFile().getParent();
+                } catch ( IOException e ) {
+                    return null;
+                }
+            }
+        } catch ( SecurityException e ) {
+            return null;
+        }
+
+        return ret;
+    }
+
+    /**
+       This class is used for emptying any stream which is passed into it in
+       a separate thread.
+     */
+    private static final class StreamGobbler extends Thread {
+
+        InputStream m_istream;
+
+        StreamGobbler( InputStream istream ) {
+            m_istream = istream;
+        }
+
+        @Override
+        public void run() {
+            try {
+                BufferedReader br = new BufferedReader(
+                    new InputStreamReader( m_istream, "UTF-8" ) );
+                // read from input stream
+                while ( br.readLine() != null ) {
+                    // don't handle line content
+                }
+                br.close();
+            } catch (UnsupportedEncodingException e) {
+                // cannot read from input stream
+            } catch ( IOException e ) {
+                // stop reading from input stream
+            }
+        }
+    }
+}

--- a/src/ag/ion/bion/officelayer/util/InstallationFinder.java
+++ b/src/ag/ion/bion/officelayer/util/InstallationFinder.java
@@ -203,8 +203,8 @@ final class InstallationFinder {
                                                SUBKEYNAME );
                 path = key.getStringValue( "" ); // default
             } catch ( WinRegKeyException we ) {
-                System.err.println( "ag.ion.bion.officelayer.util." +
-                    "InstallationFinder::getPathFromWindowsRegistry: " +
+                System.err.println( InstallationFinder.class.getName() +
+                    "::getPathFromWindowsRegistry: " +
                     "reading key from Windows Registry failed: " + we );
             }
         }
@@ -258,8 +258,8 @@ final class InstallationFinder {
                         } catch ( IOException e ) {
                             // if an I/O exception is thrown, ignore this
                             // path entry and try the next one
-                            System.err.println( "ag.ion.bion.officelayer.util." +
-                                "InstallationFinder::getPathFromEnvVar: " +
+                            System.err.println( InstallationFinder.class.getName() +
+                                "::getPathFromEnvVar: " +
                                 "bad path: " + e );
                         }
                     }
@@ -300,8 +300,8 @@ final class InstallationFinder {
             return null;
         } catch ( IOException e ) {
             // if an I/O exception is thrown, return <code>null</null>
-            System.err.println( "ag.ion.bion.officelayer.util." +
-                "InstallationFinder::getPathFromWhich: " +
+            System.err.println( InstallationFinder.class.getName() +
+                "::getPathFromWhich: " +
                 "which command failed: " + e );
             return null;
         }
@@ -340,8 +340,8 @@ final class InstallationFinder {
                 }
             } catch ( IOException e ) {
                 // if an I/O exception is thrown, return <code>null</null>
-                System.err.println( "ag.ion.bion.officelayer.util." +
-                                    "InstallationFinder::getPathFromWhich: " +
+                System.err.println( InstallationFinder.class.getName() +
+                                    "::getPathFromWhich: " +
                                     "reading which command output failed: " + e );
                 return null;
             } finally {
@@ -353,8 +353,8 @@ final class InstallationFinder {
             }
         } catch ( UnsupportedEncodingException e ) {
             // if an Encoding exception is thrown, return <code>null</null>
-            System.err.println( "ag.ion.bion.officelayer.util." +
-                                "InstallationFinder::getPathFromWhich: " +
+            System.err.println( InstallationFinder.class.getName() +
+                                "::getPathFromWhich: " +
                                 "encoding failed: " + e );
             return null;
         }
@@ -413,8 +413,8 @@ final class InstallationFinder {
                 } catch ( IOException e ) {
                     // if an I/O exception is thrown, try to analyze the lines
                     // read so far
-                    System.err.println( "ag.ion.bion.officelayer.util" +
-                        "InstallationFinder::getPathFromSVersionFile: " +
+                    System.err.println( InstallationFinder.class.getName() +
+                        "::getPathFromSVersionFile: " +
                         "reading .sversionrc file failed: " + e );
                 } finally {
                     if ( br != null ) {

--- a/src/ag/ion/bion/officelayer/util/InstallationFinder.java
+++ b/src/ag/ion/bion/officelayer/util/InstallationFinder.java
@@ -96,6 +96,9 @@ final class InstallationFinder {
         } catch ( SecurityException e ) {
             // if a SecurityException was thrown,
             // return <code>null</code>
+            System.err.println( InstallationFinder.class.getName() +
+                    "::getPath: cannot get system property " +
+		    "os.name" + e );
             return null;
         }
         if ( osname == null ) {
@@ -146,6 +149,9 @@ final class InstallationFinder {
             path = System.getProperty( prop );
         } catch ( SecurityException e ) {
             // if a SecurityException was thrown, return <code>null</code>
+            System.err.println( InstallationFinder.class.getName() +
+                    "::getPathFromProperty: cannot get system property " +
+		    prop + ": " + e );
         }
 
         return path;
@@ -170,9 +176,15 @@ final class InstallationFinder {
             path = System.getenv( var );
         } catch ( SecurityException e ) {
             // if a SecurityException was thrown, return <code>null</code>
+            System.err.println( InstallationFinder.class.getName() +
+                    "::getPathFromEnvVar: cannot get environment variable " +
+		    var + ": " + e );
         } catch ( java.lang.Error err ) {
             // System.getenv() throws java.lang.Error in Java 1.3.1 and
             // Java 1.4
+            System.err.println( InstallationFinder.class.getName() +
+                    "::getPathFromEnvVar: getting environment variables "
+		    + "not supported " + err );
         }
 
         return path;
@@ -236,10 +248,16 @@ final class InstallationFinder {
             str = System.getenv( PATH_ENVVAR_NAME );
         } catch ( SecurityException e ) {
             // if a SecurityException was thrown, return <code>null</code>
+            System.err.println( InstallationFinder.class.getName() +
+                    "::getPathFromPathEnvVar: cannot get environment variable " +
+		    PATH_ENVVAR_NAME + ": " + e );
             return null;
         } catch ( java.lang.Error err ) {
             // System.getenv() throws java.lang.Error in Java 1.3.1 and
             // Java 1.4
+            System.err.println( InstallationFinder.class.getName() +
+                    "::getPathFromPathEnvVar: getting environment variables "
+		    + "not supported " + err );
             return null;
         }
 
@@ -259,13 +277,16 @@ final class InstallationFinder {
                             // if an I/O exception is thrown, ignore this
                             // path entry and try the next one
                             System.err.println( InstallationFinder.class.getName() +
-                                "::getPathFromEnvVar: " +
+                                "::getPathFromPathEnvVar: " +
                                 "bad path: " + e );
                         }
                     }
                 } catch ( SecurityException e ) {
                     // if a SecurityException was thrown, ignore this path
                     // entry and try the next one
+                    System.err.println( InstallationFinder.class.getName() +
+                        "::getPathFromPathEnvVar: " + 
+			"security exception accessing path: "+ e );
                 }
             }
         }
@@ -297,6 +318,9 @@ final class InstallationFinder {
         try {
             proc = rt.exec( cmdArray );
         } catch ( SecurityException e ) {
+            System.err.println( InstallationFinder.class.getName() +
+                "::getPathFromWhich: " +
+                "security exception while executing which command: " + e );
             return null;
         } catch ( IOException e ) {
             // if an I/O exception is thrown, return <code>null</null>
@@ -332,6 +356,9 @@ final class InstallationFinder {
                                             break;
                                     }
                                 } catch ( SecurityException e ) {
+                                    System.err.println( InstallationFinder.class.getName() +
+                                        "::getPathFromWhich: " +
+                                        "security exception accessing file: " + e );
                                     return null;
                                 }
                             }
@@ -349,6 +376,9 @@ final class InstallationFinder {
                     br.close();
                 } catch ( IOException e ) {
                     // closing standard input stream failed, ignore
+                    System.err.println( InstallationFinder.class.getName() +
+                                        "::getPathFromWhich: " +
+                                        "reading which command output failed: " + e );
                 }
             }
         } catch ( UnsupportedEncodingException e ) {
@@ -438,6 +468,9 @@ final class InstallationFinder {
                 }
             }
         } catch ( SecurityException e ) {
+            System.err.println( InstallationFinder.class.getName() +
+                "::getPathFromSVersionFile: " +
+                "security exception accessing file: " + e );
             return null;
         }
 
@@ -510,6 +543,9 @@ final class InstallationFinder {
                         try {
                             s = new String(bytes, 0, len, "UTF-8");
                         } catch (UnsupportedEncodingException e) {
+                             System.err.println( InstallationFinder.class.getName() +
+                                                 "::getCanonicalPathFromFileURL: " +
+                                                 "encoding failed: " + e );
                             return null;
                         }
                         buf.append(s);
@@ -530,6 +566,9 @@ final class InstallationFinder {
         try {
             url = new URL(buf.toString());
         } catch (MalformedURLException e) {
+             System.err.println( InstallationFinder.class.getName() +
+                                 "::getCanonicalPathFromFileURL: " +
+                                 "invalid URL: " + e );
             return null;
         }
         String path = url.getFile();
@@ -545,10 +584,15 @@ final class InstallationFinder {
                     // resolve symlink
                     ret = file.getCanonicalFile().getParent();
                 } catch ( IOException e ) {
+                     System.err.println( InstallationFinder.class.getName() +
+                                         "::getCanonicalPathFromFileURL: " +
+                                         "error accessing file: " + e );
                     return null;
                 }
             }
         } catch ( SecurityException e ) {
+            System.err.println( InstallationFinder.class.getName() +
+                "::getCanonicalPathFromFileURL: security exception accessing file: "+ e );
             return null;
         }
 
@@ -579,8 +623,12 @@ final class InstallationFinder {
                 br.close();
             } catch (UnsupportedEncodingException e) {
                 // cannot read from input stream
+                System.err.println( StreamGobbler.class.getName() +
+                                    "::run: encoding failed: " + e );
             } catch ( IOException e ) {
                 // stop reading from input stream
+                System.err.println( StreamGobbler.class.getName() +
+                                    "::run: read from input stream failed: " + e );
             }
         }
     }

--- a/src/ag/ion/bion/officelayer/util/InstallationFinder.java
+++ b/src/ag/ion/bion/officelayer/util/InstallationFinder.java
@@ -73,6 +73,7 @@ import java.util.ArrayList;
  * the user's home directory. Note, that the .sversionrc file will be omitted
  * for OOo 2.0</p>
  */
+//FIXME: split this class into InstallationFinderUnix and InstallationFinderWindows
 final class InstallationFinder {
 
     private static final String SYSPROP_NAME =
@@ -124,6 +125,8 @@ final class InstallationFinder {
         if ( osname.startsWith( "Windows" ) ) {
             // get the installation path from the Windows Registry
             // (Windows platform only)
+	    // FIXME: this doesn't work currently as it needs unowinreg.dll
+	    // (part of Libreoffice SDK) which we don't have
             path = getPathFromWindowsRegistry();
         } else {
             // get the installation path from the PATH environment

--- a/src/ag/ion/bion/officelayer/util/InstallationFinder.java
+++ b/src/ag/ion/bion/officelayer/util/InstallationFinder.java
@@ -1,9 +1,25 @@
 /*
- * This file is part of the LibreOffice project.
+ * This file is part of noa-libre.
  *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * The Contents of this file are made available subject to
+ * the terms of GNU Lesser General Public License Version 2.1.
+ *
+ * GNU Lesser General Public License Version 2.1
+ * ========================================================================
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Publi
+ * License version 2.1, as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston
+ * MA  02111-1307  USA
  *
  * This file incorporates work covered by the following license notice:
  *

--- a/src/ag/ion/bion/officelayer/util/OfficeLoader.java
+++ b/src/ag/ion/bion/officelayer/util/OfficeLoader.java
@@ -1,0 +1,349 @@
+/*
+ * This file is part of the LibreOffice project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This file incorporates work covered by the following license notice:
+ *
+ *   Licensed to the Apache Software Foundation (ASF) under one or more
+ *   contributor license agreements. See the NOTICE file distributed
+ *   with this work for additional information regarding copyright
+ *   ownership. The ASF licenses this file to you under the Apache
+ *   License, Version 2.0 (the "License"); you may not use this file
+ *   except in compliance with the License. You may obtain a copy of
+ *   the License at http://www.apache.org/licenses/LICENSE-2.0 .
+ */
+
+package ag.ion.bion.officelayer.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Method;
+import java.net.JarURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Enumeration;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+import java.util.StringTokenizer;
+import java.util.ArrayList;
+
+/**
+ * This class can be used as a loader for application classes which use UNO.
+ *
+ * <p>The Loader class detects a UNO installation on the system and adds the
+ * UNO jar files to the search path of a customized class loader, which is used
+ * for loading the application classes.</p>
+ */
+public final class OfficeLoader {
+
+    private static ClassLoader m_Loader = null;
+
+    /**
+     * do not instantiate
+     */
+    private OfficeLoader() {}
+
+    /**
+     * The main method instantiates a customized class loader with the
+     * UNO jar files added to the search path and loads the application class,
+     * which is specified in the Main-Class attribute of the
+     * com/sun/star/lib/Loader.class entry of the manifest file or
+     * as first parameter in the argument list.
+     */
+    public static void run( String  [] arguments ) throws Exception {
+
+        // get the name of the class to be loaded from the manifest
+        String className = null;
+        Class clazz = OfficeLoader.class;
+        ClassLoader loader = clazz.getClassLoader();
+        ArrayList<URL> res = new ArrayList<URL>();
+        try {
+            Enumeration<URL> en = loader.getResources( "META-INF/MANIFEST.MF" );
+            while ( en.hasMoreElements() ) {
+                res.add( en.nextElement() );
+            }
+            // the jarfile with the com/sun/star/lib/loader/Loader.class
+            // per-entry attribute is most probably the last resource in the
+            // list, therefore search backwards
+            for ( int i = res.size() - 1; i >= 0; i-- ) {
+                URL jarurl = res.get( i );
+                try {
+                    JarURLConnection jarConnection =
+                        (JarURLConnection) jarurl.openConnection();
+                    Manifest mf = jarConnection.getManifest();
+                    Attributes attrs = mf.getAttributes(
+                        "com/sun/star/lib/loader/Loader.class" );
+                    if ( attrs != null ) {
+                        className = attrs.getValue( "Application-Class" );
+                        if ( className != null )
+                            break;
+                    }
+                } catch ( IOException e ) {
+                    // if an I/O error occurs when opening a new
+                    // JarURLConnection, ignore this manifest file
+                    System.err.println( "ag.ion.bion.officelayer.util.OfficeLoader::" +
+                                        "main: bad manifest file: " + e );
+                }
+            }
+        } catch ( IOException e ) {
+            // if an I/O error occurs when getting the manifest resources,
+            // try to get the name of the class to be loaded from the argument
+            // list
+            System.err.println( "ag.ion.bion.officelayer.util.OfficeLoader::" +
+                                "main: cannot get manifest resources: " + e );
+        }
+
+        // if no manifest entry was found, get the name of the class
+        // to be loaded from the argument list
+        String[] args;
+        if ( className == null ) {
+            if ( arguments.length > 0 ) {
+                className = arguments[0];
+                args = new String[arguments.length - 1];
+                System.arraycopy( arguments, 1, args, 0, args.length );
+            } else {
+                throw new IllegalArgumentException(
+                    "The name of the class to be loaded must be either " +
+                    "specified in the Main-Class attribute of the " +
+                    "com/sun/star/lib/loader/Loader.class entry " +
+                    "of the manifest file or as a command line argument." );
+            }
+        } else {
+            args = arguments;
+        }
+
+        // load the class with the customized class loader and
+        // invoke the main method
+        if ( className != null ) {
+            ClassLoader cl = getCustomLoader();
+            Thread.currentThread().setContextClassLoader(cl);
+            Class c = cl.loadClass( className );
+            @SuppressWarnings("unchecked")
+            Method m = c.getMethod( "main", new Class[] { String[].class } );
+            m.invoke( null, new Object[] { args } );
+        }
+    }
+
+    /**
+     * Gets the customized class loader with the UNO jar files added to the
+     * search path.
+     *
+     * @return the customized class loader
+     */
+    public static synchronized ClassLoader getCustomLoader() {
+        if ( m_Loader == null ) {
+
+            // get the urls from which to load classes and resources
+            // from the class path
+            ArrayList<URL> vec = new ArrayList<URL>();
+            String classpath = null;
+            try {
+                classpath = System.getProperty( "java.class.path" );
+            } catch ( SecurityException e ) {
+                // don't add the class path entries to the list of class
+                // loader URLs
+                System.err.println( "ag.ion.bion.officelayer.util.OfficeLoader::" +
+                    "getCustomLoader: cannot get system property " +
+                    "java.class.path: " + e );
+            }
+            if ( classpath != null ) {
+                addUrls(vec, classpath, File.pathSeparator);
+            }
+
+            // get the urls from which to load classes and resources
+            // from the UNO installation
+            String path = InstallationFinder.getPath();
+            if ( path != null ) {
+                callUnoinfo(path, vec);
+            } else {
+                System.err.println( "ag.ion.bion.officelayer.util.OfficeLoader::" +
+                    "getCustomLoader: no UNO installation found!" );
+            }
+
+            //add path to officebean jar
+	    addUrl(vec, new String(path + "/classes/officebean.jar"));
+
+            // copy urls to array
+            URL[] urls = new URL[vec.size()];
+            vec.toArray( urls );
+
+	    for( int i=0; i < vec.size(); i++) {
+		System.out.println("xxx " + vec.get(i));
+	    }
+
+            // instantiate class loader
+            m_Loader = new CustomURLClassLoader( urls );
+        }
+
+        return m_Loader;
+    }
+
+    private static void addUrls(ArrayList<URL> urls, String data, String delimiter) {
+        StringTokenizer tokens = new StringTokenizer( data, delimiter );
+        while ( tokens.hasMoreTokens() ) {
+            try {
+                urls.add( new File( tokens.nextToken() ).toURI().toURL() );
+            } catch ( MalformedURLException e ) {
+                // don't add this class path entry to the list of class loader
+                // URLs
+                System.err.println( "ag.ion.bion.officelayer.util.OfficeLoader::" +
+                    "getCustomLoader: bad pathname: " + e );
+            }
+        }
+    }
+
+    private static void addUrl(ArrayList<URL> urls, String singlePath) {
+        try {
+            urls.add( new File( singlePath).toURI().toURL() );
+        } catch ( MalformedURLException e ) {
+            // don't add this class path entry to the list of class loader
+            // URLs
+            System.err.println( "ag.ion.bion.officelayer.util.OfficeLoader::" +
+                "getCustomLoader: bad pathname: " + e );
+        }
+    }
+
+
+    private static void callUnoinfo(String path, ArrayList<URL> urls) {
+        Process p;
+        try {
+            p = Runtime.getRuntime().exec(
+                new String[] { new File(path, "unoinfo").getPath(), "java" });
+        } catch (IOException e) {
+            System.err.println(
+                "ag.ion.bion.officelayer.util.OfficeLoader::getCustomLoader: exec" +
+                " unoinfo: " + e);
+            return;
+        }
+        new Drain(p.getErrorStream()).start();
+        int code;
+        byte[] buf = new byte[1000];
+        int n = 0;
+        try {
+            InputStream s = p.getInputStream();
+            code = s.read();
+            for (;;) {
+                if (n == buf.length) {
+                    if (n > Integer.MAX_VALUE / 2) {
+                        System.err.println(
+                            "ag.ion.bion.officelayer.util.OfficeLoader::getCustomLoader:" +
+                            " too much unoinfo output");
+                        return;
+                    }
+                    byte[] buf2 = new byte[2 * n];
+                    System.arraycopy(buf, 0, buf2, 0, n);
+                    buf = buf2;
+                }
+                int k = s.read(buf, n, buf.length - n);
+                if (k == -1) {
+                    break;
+                }
+                n += k;
+            }
+        } catch (IOException e) {
+            System.err.println(
+                "ag.ion.bion.officelayer.util.OfficeLoader::getCustomLoader: reading" +
+                " unoinfo output: " + e);
+            return;
+        }
+        int ev;
+        try {
+            ev = p.waitFor();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            System.err.println(
+                "ag.ion.bion.officelayer.util.OfficeLoader::getCustomLoader: waiting for" +
+                " unoinfo: " + e);
+            return;
+        }
+        if (ev != 0) {
+            System.err.println(
+                "ag.ion.bion.officelayer.util.OfficeLoader::getCustomLoader: unoinfo"
+                + " exit value " + n);
+            return;
+        }
+        String s;
+        if (code == '0') {
+            s = new String(buf);
+        } else if (code == '1') {
+            try {
+                s = new String(buf, "UTF-16LE");
+            } catch (UnsupportedEncodingException e) {
+                System.err.println(
+                    "ag.ion.bion.officelayer.util.OfficeLoader::getCustomLoader:" +
+                    " transforming unoinfo output: " + e);
+                return;
+            }
+        } else {
+            System.err.println(
+                "ag.ion.bion.officelayer.util.OfficeLoader::getCustomLoader: bad unoinfo"
+                + " output");
+            return;
+        }
+        addUrls(urls, s, "\0");
+    }
+
+    private static final class Drain extends Thread {
+        public Drain(InputStream stream) {
+            super("unoinfo stderr drain");
+            this.stream = stream;
+        }
+
+        @Override
+        public void run() {
+            try {
+                while (stream.read() != -1) {}
+            } catch (IOException e) { /* ignored */ }
+        }
+
+        private final InputStream stream;
+    }
+
+    /**
+     * A customized class loader which is used to load classes and resources
+     * from a search path of user-defined URLs.
+     */
+    private static final class CustomURLClassLoader extends URLClassLoader {
+
+        public CustomURLClassLoader( URL[] urls ) {
+            super( urls );
+        }
+
+        @Override
+        protected Class<?> findClass( String name ) throws ClassNotFoundException {
+            // This is only called via this.loadClass -> super.loadClass ->
+            // this.findClass, after this.loadClass has already called
+            // super.findClass, so no need to call super.findClass again:
+            throw new ClassNotFoundException( name );
+        }
+
+        @Override
+        protected synchronized Class<?> loadClass( String name, boolean resolve )
+            throws ClassNotFoundException
+        {
+            Class c = findLoadedClass( name );
+            if ( c == null ) {
+                try {
+                    c = super.findClass( name );
+                } catch ( ClassNotFoundException e ) {
+                    return super.loadClass( name, resolve );
+                } catch ( SecurityException e ) {
+                    // A SecurityException "Prohibited package name: java.lang"
+                    // may occur when the user added the JVM's rt.jar to the
+                    // java.class.path:
+                    return super.loadClass( name, resolve );
+                }
+            }
+            if ( resolve ) {
+                resolveClass( c );
+            }
+            return c;
+        }
+    }
+}

--- a/src/ag/ion/bion/officelayer/util/OfficeLoader.java
+++ b/src/ag/ion/bion/officelayer/util/OfficeLoader.java
@@ -28,10 +28,13 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import java.util.StringTokenizer;
 import java.util.ArrayList;
+
+import ag.ion.bion.officelayer.application.IOfficeApplication;
 
 /**
  * This class can be used as a loader for application classes which use UNO.
@@ -44,10 +47,22 @@ public final class OfficeLoader {
 
     private static ClassLoader m_Loader = null;
 
+    private static String m_OfficePath = null;
+
     /**
      * do not instantiate
      */
     private OfficeLoader() {}
+
+    public static void init( HashMap config) {
+        if ( config.containsKey( IOfficeApplication.APPLICATION_HOME_KEY) ) {
+            Object home = config.get( IOfficeApplication.APPLICATION_HOME_KEY );
+
+	    if ( home != null ) {
+                m_OfficePath = home.toString();
+	    }
+	}
+    }
 
     /**
      * The main method instantiates a customized class loader with the
@@ -158,7 +173,8 @@ public final class OfficeLoader {
 
             // get the urls from which to load classes and resources
             // from the UNO installation
-            String path = InstallationFinder.getPath();
+            String path = (m_OfficePath != null) ? m_OfficePath : InstallationFinder.getPath();
+
             if ( path != null ) {
                 callUnoinfo(path, vec);
             } else {

--- a/src/ag/ion/bion/officelayer/util/OfficeLoader.java
+++ b/src/ag/ion/bion/officelayer/util/OfficeLoader.java
@@ -82,7 +82,7 @@ public final class OfficeLoader {
             }
         } catch ( IOException e ) {
             System.err.println( OfficeLoader.class.getName() +
-                                "::main: cannot get manifest resources: " + e );
+                                "::run: cannot get manifest resources: " + e );
         }
 
         // get the name of the class to be loaded from the argument list

--- a/src/ag/ion/bion/officelayer/util/OfficeLoader.java
+++ b/src/ag/ion/bion/officelayer/util/OfficeLoader.java
@@ -210,6 +210,8 @@ public final class OfficeLoader {
                 " unoinfo: " + e);
             return;
         }
+	//FIXME: perhaps remove this one & the whole Drain class entirely
+	//we're not doing anything w/ content of stderr anyway
         new Drain(p.getErrorStream()).start();
         int code;
         byte[] buf = new byte[1000];

--- a/src/ag/ion/bion/officelayer/util/OfficeLoader.java
+++ b/src/ag/ion/bion/officelayer/util/OfficeLoader.java
@@ -65,15 +65,12 @@ public final class OfficeLoader {
     }
 
     /**
-     * The main method instantiates a customized class loader with the
+     * This method instantiates a customized class loader with the
      * UNO jar files added to the search path and loads the application class,
-     * which is specified in the Main-Class attribute of the
-     * com/sun/star/lib/Loader.class entry of the manifest file or
-     * as first parameter in the argument list.
+     * which is specified as the first parameter in the argument list.
      */
     public static void run( String  [] arguments ) throws Exception {
 
-        // get the name of the class to be loaded from the manifest
         String className = null;
         Class clazz = OfficeLoader.class;
         ClassLoader loader = clazz.getClassLoader();
@@ -83,54 +80,21 @@ public final class OfficeLoader {
             while ( en.hasMoreElements() ) {
                 res.add( en.nextElement() );
             }
-            // the jarfile with the com/sun/star/lib/loader/Loader.class
-            // per-entry attribute is most probably the last resource in the
-            // list, therefore search backwards
-            for ( int i = res.size() - 1; i >= 0; i-- ) {
-                URL jarurl = res.get( i );
-                try {
-                    JarURLConnection jarConnection =
-                        (JarURLConnection) jarurl.openConnection();
-                    Manifest mf = jarConnection.getManifest();
-                    Attributes attrs = mf.getAttributes(
-                        "com/sun/star/lib/loader/Loader.class" );
-                    if ( attrs != null ) {
-                        className = attrs.getValue( "Application-Class" );
-                        if ( className != null )
-                            break;
-                    }
-                } catch ( IOException e ) {
-                    // if an I/O error occurs when opening a new
-                    // JarURLConnection, ignore this manifest file
-                    System.err.println( "ag.ion.bion.officelayer.util.OfficeLoader::" +
-                                        "main: bad manifest file: " + e );
-                }
-            }
         } catch ( IOException e ) {
-            // if an I/O error occurs when getting the manifest resources,
-            // try to get the name of the class to be loaded from the argument
-            // list
             System.err.println( "ag.ion.bion.officelayer.util.OfficeLoader::" +
                                 "main: cannot get manifest resources: " + e );
         }
 
-        // if no manifest entry was found, get the name of the class
-        // to be loaded from the argument list
-        String[] args;
-        if ( className == null ) {
-            if ( arguments.length > 0 ) {
-                className = arguments[0];
-                args = new String[arguments.length - 1];
-                System.arraycopy( arguments, 1, args, 0, args.length );
-            } else {
-                throw new IllegalArgumentException(
-                    "The name of the class to be loaded must be either " +
-                    "specified in the Main-Class attribute of the " +
-                    "com/sun/star/lib/loader/Loader.class entry " +
-                    "of the manifest file or as a command line argument." );
-            }
+        // get the name of the class to be loaded from the argument list
+	String[] args;
+        if ( arguments.length > 0 ) {
+            className = arguments[0];
+            args = new String[arguments.length - 1];
+            System.arraycopy( arguments, 1, args, 0, args.length );
         } else {
-            args = arguments;
+            throw new IllegalArgumentException(
+                "The name of the class to be loaded must be " +
+                "specified as a command line argument." );
         }
 
         // load the class with the customized class loader and

--- a/src/ag/ion/bion/officelayer/util/OfficeLoader.java
+++ b/src/ag/ion/bion/officelayer/util/OfficeLoader.java
@@ -169,10 +169,6 @@ public final class OfficeLoader {
             URL[] urls = new URL[vec.size()];
             vec.toArray( urls );
 
-	    for( int i=0; i < vec.size(); i++) {
-		System.out.println("xxx " + vec.get(i));
-	    }
-
             // instantiate class loader
             m_Loader = new CustomURLClassLoader( urls );
         }

--- a/src/ag/ion/bion/officelayer/util/OfficeLoader.java
+++ b/src/ag/ion/bion/officelayer/util/OfficeLoader.java
@@ -1,9 +1,25 @@
 /*
- * This file is part of the LibreOffice project.
+ * This file is part of noa-libre.
  *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * The Contents of this file are made available subject to
+ * the terms of GNU Lesser General Public License Version 2.1.
+ *
+ * GNU Lesser General Public License Version 2.1
+ * ========================================================================
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Publi
+ * License version 2.1, as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston
+ * MA  02111-1307  USA
  *
  * This file incorporates work covered by the following license notice:
  *

--- a/src/ag/ion/bion/officelayer/util/OfficeLoader.java
+++ b/src/ag/ion/bion/officelayer/util/OfficeLoader.java
@@ -81,8 +81,8 @@ public final class OfficeLoader {
                 res.add( en.nextElement() );
             }
         } catch ( IOException e ) {
-            System.err.println( "ag.ion.bion.officelayer.util.OfficeLoader::" +
-                                "main: cannot get manifest resources: " + e );
+            System.err.println( OfficeLoader.class.getName() +
+                                "::main: cannot get manifest resources: " + e );
         }
 
         // get the name of the class to be loaded from the argument list
@@ -127,8 +127,8 @@ public final class OfficeLoader {
             } catch ( SecurityException e ) {
                 // don't add the class path entries to the list of class
                 // loader URLs
-                System.err.println( "ag.ion.bion.officelayer.util.OfficeLoader::" +
-                    "getCustomLoader: cannot get system property " +
+                System.err.println( OfficeLoader.class.getName() +
+                    "::getCustomLoader: cannot get system property " +
                     "java.class.path: " + e );
             }
             if ( classpath != null ) {
@@ -142,8 +142,8 @@ public final class OfficeLoader {
             if ( path != null ) {
                 callUnoinfo(path, vec);
             } else {
-                System.err.println( "ag.ion.bion.officelayer.util.OfficeLoader::" +
-                    "getCustomLoader: no UNO installation found!" );
+                System.err.println( OfficeLoader.class.getName() +
+                    "::getCustomLoader: no UNO installation found!" );
             }
 
             //add path to officebean jar
@@ -177,8 +177,8 @@ public final class OfficeLoader {
         } catch ( MalformedURLException e ) {
             // don't add this class path entry to the list of class loader
             // URLs
-            System.err.println( "ag.ion.bion.officelayer.util.OfficeLoader::" +
-                "getCustomLoader: bad pathname: " + e );
+            System.err.println( OfficeLoader.class.getName() +
+                "::getCustomLoader: bad pathname: " + e );
         }
     }
 
@@ -190,7 +190,7 @@ public final class OfficeLoader {
                 new String[] { new File(path, "unoinfo").getPath(), "java" });
         } catch (IOException e) {
             System.err.println(
-                "ag.ion.bion.officelayer.util.OfficeLoader::getCustomLoader: exec" +
+                OfficeLoader.class.getName() + "::getCustomLoader: exec" +
                 " unoinfo: " + e);
             return;
         }
@@ -205,7 +205,7 @@ public final class OfficeLoader {
                 if (n == buf.length) {
                     if (n > Integer.MAX_VALUE / 2) {
                         System.err.println(
-                            "ag.ion.bion.officelayer.util.OfficeLoader::getCustomLoader:" +
+                            OfficeLoader.class.getName() + "::getCustomLoader:" +
                             " too much unoinfo output");
                         return;
                     }
@@ -221,7 +221,7 @@ public final class OfficeLoader {
             }
         } catch (IOException e) {
             System.err.println(
-                "ag.ion.bion.officelayer.util.OfficeLoader::getCustomLoader: reading" +
+                OfficeLoader.class.getName() + "::getCustomLoader: reading" +
                 " unoinfo output: " + e);
             return;
         }
@@ -231,13 +231,13 @@ public final class OfficeLoader {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             System.err.println(
-                "ag.ion.bion.officelayer.util.OfficeLoader::getCustomLoader: waiting for" +
+                OfficeLoader.class.getName() + "::getCustomLoader: waiting for" +
                 " unoinfo: " + e);
             return;
         }
         if (ev != 0) {
             System.err.println(
-                "ag.ion.bion.officelayer.util.OfficeLoader::getCustomLoader: unoinfo"
+                OfficeLoader.class.getName() + "::getCustomLoader: unoinfo"
                 + " exit value " + n);
             return;
         }
@@ -249,13 +249,13 @@ public final class OfficeLoader {
                 s = new String(buf, "UTF-16LE");
             } catch (UnsupportedEncodingException e) {
                 System.err.println(
-                    "ag.ion.bion.officelayer.util.OfficeLoader::getCustomLoader:" +
+                    OfficeLoader.class.getName() + "::getCustomLoader:" +
                     " transforming unoinfo output: " + e);
                 return;
             }
         } else {
             System.err.println(
-                "ag.ion.bion.officelayer.util.OfficeLoader::getCustomLoader: bad unoinfo"
+                OfficeLoader.class.getName() + "::getCustomLoader: bad unoinfo"
                 + " output");
             return;
         }

--- a/src/ag/ion/bion/officelayer/util/OfficeLoader.java
+++ b/src/ag/ion/bion/officelayer/util/OfficeLoader.java
@@ -187,14 +187,7 @@ public final class OfficeLoader {
     private static void addUrls(ArrayList<URL> urls, String data, String delimiter) {
         StringTokenizer tokens = new StringTokenizer( data, delimiter );
         while ( tokens.hasMoreTokens() ) {
-            try {
-                urls.add( new File( tokens.nextToken() ).toURI().toURL() );
-            } catch ( MalformedURLException e ) {
-                // don't add this class path entry to the list of class loader
-                // URLs
-                System.err.println( "ag.ion.bion.officelayer.util.OfficeLoader::" +
-                    "getCustomLoader: bad pathname: " + e );
-            }
+            addUrl( urls, tokens.nextToken() );
         }
     }
 

--- a/src/ag/ion/bion/officelayer/util/WinRegKey.java
+++ b/src/ag/ion/bion/officelayer/util/WinRegKey.java
@@ -81,8 +81,8 @@ final class WinRegKey {
                 System.loadLibrary( "unowinreg" );
             }
         } catch ( java.lang.Exception e ) {
-            System.err.println( "ag.ion.bion.officelayer.util.WinRegKey: " +
-                "loading of native library failed!" + e );
+            System.err.println( WinRegKey.class.getName() +
+                " loading of native library failed!" + e );
         }
     }
 

--- a/src/ag/ion/bion/officelayer/util/WinRegKey.java
+++ b/src/ag/ion/bion/officelayer/util/WinRegKey.java
@@ -1,0 +1,191 @@
+/*
+ * This file is part of the LibreOffice project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This file incorporates work covered by the following license notice:
+ *
+ *   Licensed to the Apache Software Foundation (ASF) under one or more
+ *   contributor license agreements. See the NOTICE file distributed
+ *   with this work for additional information regarding copyright
+ *   ownership. The ASF licenses this file to you under the Apache
+ *   License, Version 2.0 (the "License"); you may not use this file
+ *   except in compliance with the License. You may obtain a copy of
+ *   the License at http://www.apache.org/licenses/LICENSE-2.0 .
+ */
+
+package ag.ion.bion.officelayer.util;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+
+
+/**
+ * This class provides functionality for reading string values from the
+ * Windows Registry. It requires the native library unowinreg.dll.
+ */
+final class WinRegKey {
+
+    private final String m_rootKeyName;
+    private final String m_subKeyName;
+
+    // native methods to access the windows registry
+    private static native boolean winreg_RegOpenClassesRoot( long[] hkresult );
+    private static native boolean winreg_RegOpenCurrentConfig(
+        long[] hkresult );
+    private static native boolean winreg_RegOpenCurrentUser( long[] hkresult );
+    private static native boolean winreg_RegOpenLocalMachine( long[] hkresult );
+    private static native boolean winreg_RegOpenUsers( long[] hkresult );
+    private static native boolean winreg_RegOpenKeyEx( long parent, String name,
+        long[] hkresult );
+    private static native boolean winreg_RegCloseKey( long hkey );
+    private static native boolean winreg_RegQueryValueEx(
+        long hkey, String value, long[] type,
+        byte[] data, long[] size );
+    private static native boolean winreg_RegQueryInfoKey(
+        long hkey, long[] subkeys, long[] maxSubkeyLen,
+        long[] values, long[] maxValueNameLen,
+        long[] maxValueLen, long[] secDescriptor );
+
+    // load the native library unowinreg.dll
+    static {
+        try {
+            ClassLoader cl = WinRegKey.class.getClassLoader();
+            InputStream is = cl.getResourceAsStream( "win/unowinreg.dll" );
+            if ( is != null ) {
+                // generate a temporary name for lib file and write to temp
+                // location
+                BufferedInputStream istream = new BufferedInputStream( is );
+                File libfile = File.createTempFile( "unowinreg", ".dll" );
+                libfile.deleteOnExit(); // ensure deletion
+                BufferedOutputStream ostream = new BufferedOutputStream(
+                    new FileOutputStream( libfile ) );
+                int bsize = 2048; int n = 0;
+                byte[] buffer = new byte[bsize];
+                while ( ( n = istream.read( buffer, 0, bsize ) ) != -1 ) {
+                    ostream.write( buffer, 0, n );
+                }
+                istream.close();
+                ostream.close();
+                // load library
+                System.load( libfile.getPath() );
+            } else {
+                // If the library cannot be found as a class loader resource,
+                // try the global System.loadLibrary(). The JVM will look for
+                // it in the java.library.path.
+                System.loadLibrary( "unowinreg" );
+            }
+        } catch ( java.lang.Exception e ) {
+            System.err.println( "ag.ion.bion.officelayer.util.WinRegKey: " +
+                "loading of native library failed!" + e );
+        }
+    }
+
+    /**
+     * Constructs a <code>WinRegKey</code>.
+     */
+    public WinRegKey( String rootKeyName, String subKeyName ) {
+        m_rootKeyName = rootKeyName;
+        m_subKeyName = subKeyName;
+    }
+
+    /**
+     * Reads a string value for the specified value name.
+     */
+    public String getStringValue( String valueName ) throws WinRegKeyException {
+        byte[] data = getValue( valueName );
+        // remove terminating null character
+        return new String( data, 0, data.length - 1 );
+    }
+
+    /**
+     * Reads a value for the specified value name.
+     */
+    private byte[] getValue( String valueName ) throws WinRegKeyException {
+
+        byte[] result = null;
+        long[] hkey = {0};
+
+        // open the specified registry key
+        boolean bRet = false;
+        long[] hroot = {0};
+        if ( m_rootKeyName.equals( "HKEY_CLASSES_ROOT" ) ) {
+            bRet = winreg_RegOpenClassesRoot( hroot );
+        } else if ( m_rootKeyName.equals( "HKEY_CURRENT_CONFIG" ) ) {
+            bRet = winreg_RegOpenCurrentConfig( hroot );
+        } else if ( m_rootKeyName.equals( "HKEY_CURRENT_USER" ) ) {
+            bRet = winreg_RegOpenCurrentUser( hroot );
+        } else if ( m_rootKeyName.equals( "HKEY_LOCAL_MACHINE" ) ) {
+            bRet = winreg_RegOpenLocalMachine( hroot );
+        } else if ( m_rootKeyName.equals( "HKEY_USERS" ) ) {
+            bRet = winreg_RegOpenUsers( hroot );
+        } else {
+            throw new WinRegKeyException( "unknown root registry key!");
+        }
+        if ( !bRet ) {
+            throw new WinRegKeyException( "opening root registry key " +
+                "failed!" );
+        }
+        if ( !winreg_RegOpenKeyEx( hroot[0], m_subKeyName, hkey ) ) {
+            if ( !winreg_RegCloseKey( hroot[0] ) ) {
+                throw new WinRegKeyException( "opening registry key and " +
+                    "releasing root registry key handle failed!" );
+            }
+            throw new WinRegKeyException( "opening registry key failed!" );
+        }
+
+        // get the size of the longest data component among the key's values
+        long[] subkeys = {0};
+        long[] maxSubkeyLen = {0};
+        long[] values = {0};
+        long[] maxValueNameLen = {0};
+        long[] maxValueLen = {0};
+        long[] secDescriptor = {0};
+        if ( !winreg_RegQueryInfoKey( hkey[0], subkeys, maxSubkeyLen,
+                 values, maxValueNameLen, maxValueLen, secDescriptor ) ) {
+            if ( !winreg_RegCloseKey( hkey[0] ) ||
+                 !winreg_RegCloseKey( hroot[0] ) ) {
+                throw new WinRegKeyException( "retrieving information about " +
+                    "the registry key and releasing registry key handles " +
+                    "failed!" );
+            }
+            throw new WinRegKeyException( "retrieving information about " +
+                "the registry key failed!" );
+        }
+
+        // get the data for the specified value name
+        byte[] buffer = new byte[ (int) maxValueLen[0] ];
+        long[] size = new long[1];
+        size[0] = buffer.length;
+        long[] type = new long[1];
+        type[0] = 0;
+        if ( !winreg_RegQueryValueEx( hkey[0], valueName, type, buffer,
+                 size ) ) {
+            if ( !winreg_RegCloseKey( hkey[0] ) ||
+                 !winreg_RegCloseKey( hroot[0] ) ) {
+                throw new WinRegKeyException( "retrieving data for the " +
+                    "specified value name and releasing registry key handles " +
+                    "failed!" );
+            }
+            throw new WinRegKeyException( "retrieving data for the " +
+                "specified value name failed!" );
+        }
+
+        // release registry key handles
+        if ( !winreg_RegCloseKey( hkey[0] ) ||
+             !winreg_RegCloseKey( hroot[0] ) ) {
+            throw new WinRegKeyException( "releasing registry key handles " +
+                "failed!" );
+        }
+
+        result = new byte[ (int) size[0] ];
+        System.arraycopy( buffer, 0, result, 0, (int)size[0] );
+
+        return result;
+    }
+}

--- a/src/ag/ion/bion/officelayer/util/WinRegKey.java
+++ b/src/ag/ion/bion/officelayer/util/WinRegKey.java
@@ -69,6 +69,7 @@ final class WinRegKey {
         long[] maxValueLen, long[] secDescriptor );
 
     // load the native library unowinreg.dll
+    // FIXME: drop dependency on unowinreg.dll and use com.ice.jni.registry instead
     static {
         try {
             ClassLoader cl = WinRegKey.class.getClassLoader();

--- a/src/ag/ion/bion/officelayer/util/WinRegKey.java
+++ b/src/ag/ion/bion/officelayer/util/WinRegKey.java
@@ -1,9 +1,25 @@
 /*
- * This file is part of the LibreOffice project.
+ * This file is part of noa-libre.
  *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * The Contents of this file are made available subject to
+ * the terms of GNU Lesser General Public License Version 2.1.
+ *
+ * GNU Lesser General Public License Version 2.1
+ * ========================================================================
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Publi
+ * License version 2.1, as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston
+ * MA  02111-1307  USA
  *
  * This file incorporates work covered by the following license notice:
  *

--- a/src/ag/ion/bion/officelayer/util/WinRegKeyException.java
+++ b/src/ag/ion/bion/officelayer/util/WinRegKeyException.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the LibreOffice project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This file incorporates work covered by the following license notice:
+ *
+ *   Licensed to the Apache Software Foundation (ASF) under one or more
+ *   contributor license agreements. See the NOTICE file distributed
+ *   with this work for additional information regarding copyright
+ *   ownership. The ASF licenses this file to you under the Apache
+ *   License, Version 2.0 (the "License"); you may not use this file
+ *   except in compliance with the License. You may obtain a copy of
+ *   the License at http://www.apache.org/licenses/LICENSE-2.0 .
+ */
+
+package ag.ion.bion.officelayer.util;
+
+/**
+ * WinRegKeyException is a checked exception.
+ */
+final class WinRegKeyException extends java.lang.Exception {
+
+    /**
+     * Constructs a <code>WinRegKeyException</code>.
+     */
+    public WinRegKeyException() {
+        super();
+    }
+
+    /**
+     * Constructs a <code>WinRegKeyException</code> with the specified
+     * detail message.
+     *
+     * @param  message   the detail message
+     */
+    public WinRegKeyException( String message ) {
+        super( message );
+    }
+}

--- a/src/ag/ion/bion/officelayer/util/WinRegKeyException.java
+++ b/src/ag/ion/bion/officelayer/util/WinRegKeyException.java
@@ -1,9 +1,25 @@
 /*
- * This file is part of the LibreOffice project.
+ * This file is part of noa-libre.
  *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * The Contents of this file are made available subject to
+ * the terms of GNU Lesser General Public License Version 2.1.
+ *
+ * GNU Lesser General Public License Version 2.1
+ * ========================================================================
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Publi
+ * License version 2.1, as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston
+ * MA  02111-1307  USA
  *
  * This file incorporates work covered by the following license notice:
  *


### PR DESCRIPTION
This pull request adds a new OfficeLoader class that will try to find UNO installation on the system, in the following order of priority:

1. Path from noa configuration (IOfficeApplication.APPLICATION_HOME_KEY)
2.  com.sun.star.lib.loader.unopath Java property
3.  UNO_PATH environment variable
4a.  (Windows only) Registry key Software\\LibreOffice\\UNO\\InstallPath
4b. (Linux/Mac) PATH env.variable
5.  (Linux/Mac) 'which soffice'

OfficeLoader contains a customized URLClassLoader that is, using the URLs gathered as described above,  meant to load NOA and UNO classes so no more hard-coded paths in the manifest, hurray \o/  OfficeLoader::run() can be used to kick off any NOA app. It will load its primary class of by name and call its main method. This is demonstrated in Lo4ConnectionTest example


 It contains a customized URLClassLoader which is meant to be used to load all NOA classes