### PR TITLE
Updated .gitignore for IntellIJ files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 /build/
 /dist/
 /manifest.mf
+*.iml
+# IntelliJ Directories
+.idea/
+out/
+.settings/
 *~


### PR DESCRIPTION
I just added the IntelliJ config files to the .gitignore so it does not interfere with any dev modules whatsoever. Directories such as .idea/, .settings/, and out/ are one of them. As for files, .iml have also been added to the gitignore. 